### PR TITLE
fix(http): send query.attributes in findTraces so attribute filters work over HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ like VS Code, Claude, Cursor, Windsurf Github Copilot via the `jaeger-mcp-server
                 "booleanAttribute": true,
             }
             ```
+                         When using HTTP (`JAEGER_PROTOCOL=HTTP`), the client sends attributes as the
+                         `query.attributes` query parameter (URL-encoded JSON map), matching the Jaeger API v3 format.
    - `startTimeMin`:
        - `Mandatory`: `true`
        - `Type`: `string`


### PR DESCRIPTION
## Summary

HTTP client `findTraces` did not send `query.attributes` to the Jaeger API, so attribute filters were ignored when using `JAEGER_PROTOCOL=HTTP`. This change adds attribute query params so behavior matches gRPC.

## Changes

- **`src/client/jaeger-http-client.ts`**: When `request.query.attributes` is present and non-empty, add `query.attributes` to the GET request params as a JSON string (Axios URL-encodes it). Added JSDoc describing the HTTP API format.
- **`README.md`**: Document that when using HTTP, the client sends attributes as the `query.attributes` query parameter (URL-encoded JSON map) per Jaeger API v3.

## Acceptance criteria (from #3)

- [x] HTTP client `findTraces` includes attribute query params when `request.query.attributes` is present.
- [x] Behavior matches gRPC: filtering by attributes works over HTTP (once the server supports it; see jaegertracing/jaeger#7594 and related PRs).
- [x] README/code comment documents the HTTP attribute param format.

## References

- Fixes #3
- Epic: #11 (HTTP find-traces parity)
- Replaces #14 (same changes, reopened after history cleanup).